### PR TITLE
Specifying an xgboost dependency version so function enhanceFeatures() works

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     mclust,
     RCurl,
     DirichletReg,
-    xgboost,
+    xgboost (== 1.7.6),
     utils,
     dplyr,
     rlang,


### PR DESCRIPTION
Heya.

So if installing the package as it is, it downloads the latest xgboost package version and then the function enhanceFeatures() breaks. Namely, here is an error:

```
datasets_enhanced[[1]] <- enhanceFeatures(datasets_enhanced[[1]], datasets[[1]], 
                                    model = "xgboost", 
                                     feature_names=rownames(rowData(datasets_enhanced[[1]])),
                                     nrounds=0)

Warning message in check.deprecation(deprecated_train_params, match.call(), ...):
“Passed invalid function arguments: max_depth, eta. These should be passed as a list to argument 'params'. Conversion from argument to 'params' entry will be done automatically, but this behavior will become an error in a future version.”
Warning message in throw_err_or_depr_msg("Parameter '", match_old, "' has been renamed to '", :
“Parameter 'watchlist' has been renamed to 'evals'. This warning will become an error in a future version.”
Warning message in check.custom.obj(params, objective):
“Argument 'objective' is only for custom objectives. For built-in objectives, pass the objective under 'params'. This warning will become an error in a future version.”
Warning message in throw_err_or_depr_msg("Passed unrecognized parameters: ", paste(head(names_unrecognized), :
“Passed unrecognized parameters: verbose. This warning will become an error in a future version.”
Warning message in throw_err_or_depr_msg("Parameter '", match_old, "' has been renamed to '", :
“Parameter 'data' has been renamed to 'x'. This warning will become an error in a future version.”
Warning message in throw_err_or_depr_msg("Parameter '", match_old, "' has been renamed to '", :
“Parameter 'label' has been renamed to 'y'. This warning will become an error in a future version.”
Warning message in throw_err_or_depr_msg("Parameter '", match_old, "' has been renamed to '", :
“Parameter 'eta' has been renamed to 'learning_rate'. This warning will become an error in a future version.”

Error in begin_iteration:end_iteration: argument of length 0
Traceback:

1. .enhance_features(X.enhanced, X.ref, Y.ref, feature_names, model, 
 .     nrounds, train.n)
2. .xgboost_enhance(X.ref, X.enhanced, Y.ref, feature_names, nrounds, 
 .     train.n)
3. xgboost(data = X.ref, label = Y.ref[feature, ], objective = "reg:squarederror", 
 .     max_depth = 2, eta = 0.03, nrounds = nrounds, nthread = 1, 
 .     verbose = FALSE)
4. xgb.train(params = params, data = dm, nrounds = nrounds, verbose = verbosity, 
 .     print_every_n = print_every_n, evals = evals)
5. .handleSimpleError(function (cnd) 
 . {
 .     watcher$capture_plot_and_output()
 .     cnd <- sanitize_call(cnd)
 .     watcher$push(cnd)
 .     switch(on_error, continue = invokeRestart("eval_continue"), 
 .         stop = invokeRestart("eval_stop"), error = NULL)
 . }, "argument of length 0", base::quote(begin_iteration:end_iteration))
```

I can confirm that, with downgrading xgboost, it works without issues. In my case, I downgraded to r-xgboost 1.7.6 (also specficied in the commit).

```
sessionInfo()
R version 4.3.3 (2024-02-29)
Platform: x86_64-conda-linux-gnu (64-bit)
Running under: Red Hat Enterprise Linux 8.9 (Ootpa)

Matrix products: default

attached base packages:
[1] stats4    stats     graphics  grDevices utils     datasets  methods  
[8] base     

other attached packages:
 [1] here_1.0.1                  ggplot2_3.5.2              
 [3] BayesSpace_1.12.0           SingleCellExperiment_1.24.0
 [5] SummarizedExperiment_1.32.0 Biobase_2.62.0             
 [7] GenomicRanges_1.54.1        GenomeInfoDb_1.38.8        
 [9] IRanges_2.36.0              S4Vectors_0.40.2           
[11] BiocGenerics_0.48.1         MatrixGenerics_1.14.0      
[13] matrixStats_1.5.0           xgboost_1.7.6.1            

loaded via a namespace (and not attached):
  [1] DBI_1.2.3                 bitops_1.0-9             
  [3] gridExtra_2.3             sandwich_3.1-1           
  [5] DirichletReg_0.7-1        rlang_1.1.6              
  [7] magrittr_2.0.3            scater_1.30.1            
  [9] compiler_4.3.3            RSQLite_2.3.9            
 [11] DelayedMatrixStats_1.24.0 vctrs_0.6.5              
 [13] pkgconfig_2.0.3           crayon_1.5.3             
 [15] fastmap_1.2.0             dbplyr_2.5.0             
 [17] XVector_0.42.0            labeling_0.4.3           
 [19] scuttle_1.12.0            ggbeeswarm_0.7.2         
 [21] miscTools_0.6-28          purrr_1.0.4              
 [23] bit_4.6.0                 bluster_1.12.0           
 [25] zlibbioc_1.48.0           cachem_1.1.0             
 [27] beachmat_2.18.0           jsonlite_2.0.0           
 [29] blob_1.2.4                rhdf5filters_1.14.1      
 [31] DelayedArray_0.28.0       uuid_1.2-1               
 [33] Rhdf5lib_1.24.0           BiocParallel_1.36.0      
 [35] cluster_2.1.8.1           irlba_2.3.5.1            
 [37] parallel_4.3.3            R6_2.6.1                 
 [39] limma_3.58.1              Rcpp_1.0.14              
 [41] IRkernel_1.3.2            assertthat_0.2.1         
 [43] zoo_1.8-14                base64enc_0.1-3          
 [45] pacman_0.5.1              igraph_2.0.3             
 [47] Matrix_1.6-5              tidyselect_1.2.1         
 [49] abind_1.4-5               viridis_0.6.5            
 [51] maxLik_1.5-2.1            codetools_0.2-20         
 [53] curl_6.2.2                lattice_0.22-7           
 [55] tibble_3.2.1              withr_3.0.2              
 [57] coda_0.19-4.1             evaluate_1.0.3           
 [59] BiocFileCache_2.10.1      mclust_6.1.1             
 [61] pillar_1.10.2             filelock_1.0.3           
 [63] generics_0.1.3            rprojroot_2.0.4          
 [65] RCurl_1.98-1.16           IRdisplay_1.1            
 [67] sparseMatrixStats_1.14.0  munsell_0.5.1            
 [69] scales_1.3.0              glue_1.8.0               
 [71] metapod_1.10.0            tools_4.3.3              
 [73] BiocNeighbors_1.20.0      data.table_1.17.0        
 [75] ScaledMatrix_1.10.0       locfit_1.5-9.12          
 [77] pbdZMQ_0.3-14             scran_1.30.0             
 [79] Cairo_1.6-2               rhdf5_2.46.1             
 [81] grid_4.3.3                edgeR_4.0.16             
 [83] colorspace_2.1-1          GenomeInfoDbData_1.2.11  
 [85] repr_1.1.7                beeswarm_0.4.0           
 [87] BiocSingular_1.18.0       vipor_0.4.7              
 [89] Formula_1.2-5             cli_3.6.4                
 [91] rsvd_1.0.5                S4Arrays_1.2.0           
 [93] viridisLite_0.4.2         dplyr_1.1.4              
 [95] gtable_0.3.6              digest_0.6.37            
 [97] dqrng_0.3.2               SparseArray_1.2.2        
 [99] ggrepel_0.9.6             farver_2.1.2             
[101] memoise_2.0.1             htmltools_0.5.8.1        
[103] lifecycle_1.0.4           httr_1.4.7               
[105] statmod_1.5.0             bit64_4.6.0-1 
```