### PR TITLE
fix: Add nthread parameter to enhanceFeatures

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     mclust,
     RCurl,
     DirichletReg,
-    xgboost (< 2.0.0),
+    xgboost (>= 3),
     utils,
     dplyr,
     rlang,

--- a/R/enhanceFeatures.R
+++ b/R/enhanceFeatures.R
@@ -20,6 +20,8 @@
 #'   runtime.
 #' @param train.n Number of spots to use in the training dataset for tuning
 #'   nrounds. By default, 2/3 the total number of spots are used.
+#' @param nthread Number of threads used by xgboost. Set to 1 (default) to
+#'   respect system thread limits.
 #' 
 #' @return If \code{assay.type} or \code{altExp.type} are specified, the
 #'   enhanced features are stored in the corresponding slot of
@@ -57,9 +59,9 @@
 NULL
 
 #' @importFrom assertthat assert_that
-.enhance_features <- function(X.enhanced, X.ref, Y.ref, 
-    feature_names = rownames(Y.ref), model = c("xgboost", "dirichlet", "lm"), 
-    nrounds, train.n) {
+.enhance_features <- function(X.enhanced, X.ref, Y.ref,
+    feature_names = rownames(Y.ref), model = c("xgboost", "dirichlet", "lm"),
+    nrounds, train.n, nthread) {
 
     assert_that(ncol(X.enhanced) == ncol(X.ref))
     assert_that(ncol(Y.ref) == nrow(X.ref))
@@ -81,7 +83,7 @@ NULL
     } else if (model == "dirichlet") {
         .dirichlet_enhance(X.ref, X.enhanced, Y.ref)
     } else if (model == "xgboost") {
-        .xgboost_enhance(X.ref, X.enhanced, Y.ref, feature_names, nrounds, train.n)
+        .xgboost_enhance(X.ref, X.enhanced, Y.ref, feature_names, nrounds, train.n, nthread)
     }
 }
 
@@ -121,8 +123,8 @@ NULL
 }
 
 #' @importFrom xgboost xgboost xgb.DMatrix xgb.train
-.xgboost_enhance <- function(X.ref, X.enhanced, Y.ref, feature_names, 
-                             nrounds, train.n) {
+.xgboost_enhance <- function(X.ref, X.enhanced, Y.ref, feature_names,
+                             nrounds, train.n, nthread) {
 
     Y.enhanced <- matrix(nrow=length(feature_names), ncol=nrow(X.enhanced))
     rownames(Y.enhanced) <- feature_names
@@ -149,13 +151,13 @@ NULL
             fit.train <- xgb.train(data=data.train, max_depth=2,
                                    watchlist=watchlist, eta=0.03, nrounds=500,
                                    objective="reg:squarederror",
-                                   nthread=1, verbose=FALSE)
+                                   nthread=nthread, verbose=FALSE)
             nrounds <- which.min(fit.train$evaluation_log$test_rmse)
         }
         
-        fit <- xgboost(data=X.ref, label=Y.ref[feature, ], 
+        fit <- xgboost(data=X.ref, label=Y.ref[feature, ],
             objective="reg:squarederror", max_depth=2, eta=0.03,
-            nrounds=nrounds, nthread=1, verbose=FALSE)
+            nrounds=nrounds, nthread=nthread, verbose=FALSE)
         
         Y.enhanced[feature, ] <- predict(fit, X.enhanced)
         rmse[feature] <- fit$evaluation_log$train_rmse[nrounds]
@@ -174,7 +176,7 @@ NULL
 enhanceFeatures <- function(sce.enhanced, sce.ref, feature_names = NULL,
     model=c("xgboost", "dirichlet", "lm"), use.dimred = "PCA",
     assay.type="logcounts", altExp.type = NULL, feature.matrix = NULL,
-    nrounds = 0, train.n = round(ncol(sce.ref)*2/3)) {
+    nrounds = 0, train.n = round(ncol(sce.ref)*2/3), nthread = 1L) {
     
     X.enhanced <- reducedDim(sce.enhanced, use.dimred)
     X.ref <- reducedDim(sce.ref, use.dimred)
@@ -206,8 +208,8 @@ enhanceFeatures <- function(sce.enhanced, sce.ref, feature_names = NULL,
         }
     }
     
-    Y.enhanced <- .enhance_features(X.enhanced, X.ref, Y.ref, feature_names, 
-                                    model, nrounds, train.n)
+    Y.enhanced <- .enhance_features(X.enhanced, X.ref, Y.ref, feature_names,
+                                    model, nrounds, train.n, nthread)
 
     ## Clip negative predicted expression
     Y.enhanced <- pmax(Y.enhanced, 0)

--- a/R/enhanceFeatures.R
+++ b/R/enhanceFeatures.R
@@ -146,10 +146,10 @@ NULL
                                       label=Y.ref[feature, -train.index])
             watchlist <- list(train=data.train, test=data.test)
             
-            fit.train <- xgb.train(data=data.train, max_depth=2, 
+            fit.train <- xgb.train(data=data.train, max_depth=2,
                                    watchlist=watchlist, eta=0.03, nrounds=500,
                                    objective="reg:squarederror",
-                                   verbose=FALSE)
+                                   nthread=1, verbose=FALSE)
             nrounds <- which.min(fit.train$evaluation_log$test_rmse)
         }
         

--- a/R/enhanceFeatures.R
+++ b/R/enhanceFeatures.R
@@ -146,18 +146,18 @@ NULL
                                       label=Y.ref[feature, train.index])
             data.test  <- xgb.DMatrix(data=X.ref[-train.index, ], 
                                       label=Y.ref[feature, -train.index])
-            watchlist <- list(train=data.train, test=data.test)
-            
+            evals <- list(train=data.train, test=data.test)
+
             fit.train <- xgb.train(data=data.train, max_depth=2,
-                                   watchlist=watchlist, eta=0.03, nrounds=500,
+                                   evals=evals, eta=0.03, nrounds=500,
                                    objective="reg:squarederror",
-                                   nthread=nthread, verbose=FALSE)
+                                   nthread=nthread, verbosity=0)
             nrounds <- which.min(fit.train$evaluation_log$test_rmse)
         }
         
-        fit <- xgboost(data=X.ref, label=Y.ref[feature, ],
-            objective="reg:squarederror", max_depth=2, eta=0.03,
-            nrounds=nrounds, nthread=nthread, verbose=FALSE)
+        fit <- xgboost(x=X.ref, y=Y.ref[feature, ],
+            objective="reg:squarederror", max_depth=2, learning_rate=0.03,
+            nrounds=nrounds, nthreads=nthread, verbosity=0)
         
         Y.enhanced[feature, ] <- predict(fit, X.enhanced)
         rmse[feature] <- fit$evaluation_log$train_rmse[nrounds]

--- a/tests/testthat/test-enhanceFeatures.R
+++ b/tests/testthat/test-enhanceFeatures.R
@@ -31,8 +31,8 @@ test_that("genes are predicted with linear model", {
 
 test_that("genes are predicted with xgboost", {
   gene <- "gene_4"
-  fit <- xgboost(data=X.ref, label=Y.ref[gene, ], objective="reg:squarederror",
-                 max_depth=2, eta=0.03, nrounds=100, nthread=1, verbose=FALSE)
+  fit <- xgboost(x=X.ref, y=Y.ref[gene, ], objective="reg:squarederror",
+                 max_depth=2, learning_rate=0.03, nrounds=100, nthreads=1, verbosity=0)
   new <- predict(fit, newdata=X.enhanced)
   
   Y.enhanced <- .xgboost_enhance(X.ref, X.enhanced, Y.ref, c(gene), nrounds = 100)
@@ -51,17 +51,17 @@ test_that("genes are predicted with tuned xgboost", {
                             label=Y.ref[gene, train.index])
   data.test  <- xgb.DMatrix(data=X.ref[-train.index, ],
                             label=Y.ref[gene, -train.index])
-  watchlist <- list(train=data.train, test=data.test)
-  
-  fit.train <- xgb.train(data=data.train, max_depth=2, watchlist=watchlist,
+  evals <- list(train=data.train, test=data.test)
+
+  fit.train <- xgb.train(data=data.train, max_depth=2, evals=evals,
                          eta=0.03, nrounds=500, objective="reg:squarederror",
-                         verbose=FALSE)
+                         verbosity=0)
   
   nrounds <- which.min(fit.train$evaluation_log$test_rmse)
   
-  fit <- xgboost(data=X.ref, label=Y.ref[gene, ], objective="reg:squarederror",
-                 max_depth=2, eta=0.03, nrounds=nrounds, nthread=1, 
-                 verbose=FALSE)
+  fit <- xgboost(x=X.ref, y=Y.ref[gene, ], objective="reg:squarederror",
+                 max_depth=2, learning_rate=0.03, nrounds=nrounds, nthreads=1,
+                 verbosity=0)
   new <- predict(fit, newdata=X.enhanced)
   
   set.seed(100)


### PR DESCRIPTION
# Summary

Related to #152 

This PR adds a parameter, `nthread` to `enhanceFeatures()`, that controls the number of threads used by xgboost functions.

Previously `nthread` was hard-coded to 1 when calling `xgboost`, and not specified when calling `xgb.train()`.

Setting the default to 1 should address the issue raised in #152.