### PR TITLE
fix: xgboost 3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     mclust,
     RCurl,
     DirichletReg,
-    xgboost (< 2.0.0),
+    xgboost (>= 3),
     utils,
     dplyr,
     rlang,

--- a/R/enhanceFeatures.R
+++ b/R/enhanceFeatures.R
@@ -146,18 +146,18 @@ NULL
                                       label=Y.ref[feature, train.index])
             data.test  <- xgb.DMatrix(data=X.ref[-train.index, ], 
                                       label=Y.ref[feature, -train.index])
-            watchlist <- list(train=data.train, test=data.test)
-            
+            evals <- list(train=data.train, test=data.test)
+
             fit.train <- xgb.train(data=data.train, max_depth=2,
-                                   watchlist=watchlist, eta=0.03, nrounds=500,
+                                   evals=evals, eta=0.03, nrounds=500,
                                    objective="reg:squarederror",
-                                   nthread=nthread, verbose=FALSE)
+                                   nthread=nthread, verbosity=0)
             nrounds <- which.min(fit.train$evaluation_log$test_rmse)
         }
         
-        fit <- xgboost(data=X.ref, label=Y.ref[feature, ],
-            objective="reg:squarederror", max_depth=2, eta=0.03,
-            nrounds=nrounds, nthread=nthread, verbose=FALSE)
+        fit <- xgboost(x=X.ref, y=Y.ref[feature, ],
+            objective="reg:squarederror", max_depth=2, learning_rate=0.03,
+            nrounds=nrounds, nthreads=nthread, verbosity=0)
         
         Y.enhanced[feature, ] <- predict(fit, X.enhanced)
         rmse[feature] <- fit$evaluation_log$train_rmse[nrounds]

--- a/tests/testthat/test-enhanceFeatures.R
+++ b/tests/testthat/test-enhanceFeatures.R
@@ -31,8 +31,8 @@ test_that("genes are predicted with linear model", {
 
 test_that("genes are predicted with xgboost", {
   gene <- "gene_4"
-  fit <- xgboost(data=X.ref, label=Y.ref[gene, ], objective="reg:squarederror",
-                 max_depth=2, eta=0.03, nrounds=100, nthread=1, verbose=FALSE)
+  fit <- xgboost(x=X.ref, y=Y.ref[gene, ], objective="reg:squarederror",
+                 max_depth=2, learning_rate=0.03, nrounds=100, nthreads=1, verbosity=0)
   new <- predict(fit, newdata=X.enhanced)
   
   Y.enhanced <- .xgboost_enhance(X.ref, X.enhanced, Y.ref, c(gene), nrounds = 100)
@@ -51,17 +51,17 @@ test_that("genes are predicted with tuned xgboost", {
                             label=Y.ref[gene, train.index])
   data.test  <- xgb.DMatrix(data=X.ref[-train.index, ],
                             label=Y.ref[gene, -train.index])
-  watchlist <- list(train=data.train, test=data.test)
-  
-  fit.train <- xgb.train(data=data.train, max_depth=2, watchlist=watchlist,
+  evals <- list(train=data.train, test=data.test)
+
+  fit.train <- xgb.train(data=data.train, max_depth=2, evals=evals,
                          eta=0.03, nrounds=500, objective="reg:squarederror",
-                         verbose=FALSE)
+                         verbosity=0)
   
   nrounds <- which.min(fit.train$evaluation_log$test_rmse)
   
-  fit <- xgboost(data=X.ref, label=Y.ref[gene, ], objective="reg:squarederror",
-                 max_depth=2, eta=0.03, nrounds=nrounds, nthread=1, 
-                 verbose=FALSE)
+  fit <- xgboost(x=X.ref, y=Y.ref[gene, ], objective="reg:squarederror",
+                 max_depth=2, learning_rate=0.03, nrounds=nrounds, nthreads=1,
+                 verbosity=0)
   new <- predict(fit, newdata=X.enhanced)
   
   set.seed(100)


### PR DESCRIPTION
# Summary

This PR removes the constraint on xgboost <2, and replaces it with a minimum required version of xgboost 3.

Calls to `xgboost` and `xgb.train` were updated to reflect the xgboost 3 API.